### PR TITLE
Add function to check if starts with currency

### DIFF
--- a/src/underscore/underscore-extensions.coffee
+++ b/src/underscore/underscore-extensions.coffee
@@ -37,10 +37,12 @@ class Utils
     else
       return wholePart
 
-
-  intAsCurrency: (value, options) =>
-    (options?.currencySymbol or @_getCurrency()) + @formatCurrency(value/100, options)
-
+  intAsCurrency: (value, options) ->
+    currencySymbol = if options and options.currencySymbol then options.currencySymbol else @_getCurrency()
+    startsWithCurrency = if options and options.currencySymbol then options.currencySymbol else @_getStartsWithCurrency()
+    if startsWithCurrency
+      return currencySymbol + utils.formatCurrency(value / 100, options)
+    return utils.formatCurrency(value / 100, options) + ' ' + currencySymbol
   ###
   Pads a string until it reaches a certain length. Non-strings will be converted.
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adicionar função para checar se o símbolo da moeda deve começar antes do valor monetário.

#### What problem is this solving?
https://github.com/vtex/vcs.checkout-ui/issues/401#

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/7591901/30650693-f36e7426-9df9-11e7-906d-c8e5e7f2a2e8.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
