### PR TITLE
Change way to export class

### DIFF
--- a/src/underscore/underscore-extensions.coffee
+++ b/src/underscore/underscore-extensions.coffee
@@ -41,8 +41,8 @@ class Utils
     currencySymbol = if options and options.currencySymbol then options.currencySymbol else @_getCurrency()
     startsWithCurrency = if options and options.currencySymbol then options.currencySymbol else @_getStartsWithCurrency()
     if startsWithCurrency
-      return currencySymbol + Utils.formatCurrency(value / 100, options)
-    return Utils.formatCurrency(value / 100, options) + ' ' + currencySymbol
+      return currencySymbol + _.formatCurrency(value / 100, options)
+    return _.formatCurrency(value / 100, options) + ' ' + currencySymbol
   ###
   Pads a string until it reaches a certain length. Non-strings will be converted.
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Mudar a forma de instanciar a classe Utils.

#### What problem is this solving?
A função `formatCurrency` era chamada `utils.formatCurrency`, só que a classe é exportada com underscore.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/7591901/30716162-65f1f892-9eef-11e7-8169-4aacf96ff97e.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
