### PR TITLE
Fix polyfill underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "front.utils",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "readmeFilename": "README.md",
   "description": "Common front end utils",
   "deploy": "deploy/",

--- a/src/underscore/underscore-extensions.coffee
+++ b/src/underscore/underscore-extensions.coffee
@@ -418,7 +418,8 @@ class Utils
 
    _getStartsWithCurrency: =>
     if window.vtex?.i18n?.getStartsWithCurrency
-      return window.vtex?.i18n?.getStartsWithCurrency()
+      startsWithCurrency = window.vtex?.i18n?.getStartsWithCurrency()
+      return if startsWithCurrency? then startsWithCurrency else true
     else
       return true
 

--- a/src/underscore/underscore-extensions.coffee
+++ b/src/underscore/underscore-extensions.coffee
@@ -437,5 +437,13 @@ class Utils
 
     return obj
 
-# exports
-window?._?.mixin?(new Utils())
+utils = new Utils()
+if window._? # Is Underscore namespace being used?
+	if window._.mixin? # Is it underscore?
+    window._.mixin(utils) # Mixin it
+  else
+    utils._extend(window._, utils) # Extend this thing
+else
+	window._ = utils # Take namespace
+	# polyfill for Underscores's extend
+	window._.extend = utils._extend


### PR DESCRIPTION
Estou atualizando esse arquivo que é carregado no Portal antigo.

Antes era feito dessa forma:
https://github.com/vtex/front.utils/blob/v1.0.1/src/coffee/vtex-utils.coffee#L310-L318

Nas ultimas alterações esse trecho ficou de fora.

Como no Portal não é inserido o Underscore, esse arquivo parou de funcionar. Esse PR traz justamente esse trecho de codigo que permite que ele funcione sem o Underscore na pagina.